### PR TITLE
feat: 여행지 및 항공사 CRUD 구현 #2

### DIFF
--- a/src/main/java/com/example/travelbag/domain/location/controller/LocationController.java
+++ b/src/main/java/com/example/travelbag/domain/location/controller/LocationController.java
@@ -1,0 +1,31 @@
+package com.example.travelbag.domain.location.controller;
+
+import com.example.travelbag.domain.location.controller.api.LocationApi;
+import com.example.travelbag.domain.location.dto.AirlineResponseDTO;
+import com.example.travelbag.domain.location.dto.LocationResponseDTO;
+import com.example.travelbag.domain.location.service.LocationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class LocationController implements LocationApi {
+
+    @Autowired
+    private LocationService locationService;
+
+    @Override
+    public ResponseEntity<List<LocationResponseDTO>> getLocations() {
+        List<LocationResponseDTO> locations = locationService.getLocations();
+        return ResponseEntity.ok(locations);
+    }
+
+    @Override
+    public ResponseEntity<List<AirlineResponseDTO>> getAirlinesByLocation(@RequestParam(value="location_id") Long location_id) {
+        List<AirlineResponseDTO> airlines = locationService.getAirlinesByLocation(location_id);
+        return ResponseEntity.ok(airlines);
+    }
+}

--- a/src/main/java/com/example/travelbag/domain/location/controller/api/LocationApi.java
+++ b/src/main/java/com/example/travelbag/domain/location/controller/api/LocationApi.java
@@ -1,0 +1,20 @@
+package com.example.travelbag.domain.location.controller.api;
+
+import com.example.travelbag.domain.location.dto.AirlineResponseDTO;
+import com.example.travelbag.domain.location.dto.LocationResponseDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@RequestMapping("/location")
+public interface LocationApi {
+
+    @GetMapping()
+    ResponseEntity<List<LocationResponseDTO>> getLocations();
+
+    @GetMapping("/airline")
+    ResponseEntity<List<AirlineResponseDTO>> getAirlinesByLocation(@RequestParam(value="location_id") Long location_id);
+}

--- a/src/main/java/com/example/travelbag/domain/location/dto/AirlineResponseDTO.java
+++ b/src/main/java/com/example/travelbag/domain/location/dto/AirlineResponseDTO.java
@@ -1,0 +1,30 @@
+package com.example.travelbag.domain.location.dto;
+
+import com.example.travelbag.domain.location.entity.Airline;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AirlineResponseDTO {
+    private Long id;
+    private String name;
+    private String url;
+    private LocalDateTime createdDate;
+    private LocalDateTime lastModifiedDate;
+
+    // Airline 객체를 받아서 DTO 객체로 변환
+    public static AirlineResponseDTO of(Airline airline) {
+        return AirlineResponseDTO.builder()
+                .id(airline.getId())
+                .name(airline.getName())
+                .url(airline.getUrl())
+                .createdDate(airline.getCreatedDate())
+                .lastModifiedDate(airline.getLastModifiedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/travelbag/domain/location/dto/LocationResponseDTO.java
+++ b/src/main/java/com/example/travelbag/domain/location/dto/LocationResponseDTO.java
@@ -1,0 +1,28 @@
+package com.example.travelbag.domain.location.dto;
+
+import com.example.travelbag.domain.location.entity.Location;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LocationResponseDTO {
+    private Long id;
+    private String name;
+    private LocalDateTime createdDate;
+    private LocalDateTime lastModifiedDate;
+
+    // Location 객체를 받아서 DTO 객체로 변환
+    public static LocationResponseDTO of(Location location) {
+        return LocationResponseDTO.builder()
+                .id(location.getId())
+                .name(location.getName())
+                .createdDate(location.getCreatedDate())
+                .lastModifiedDate(location.getLastModifiedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/travelbag/domain/location/entity/Airline.java
+++ b/src/main/java/com/example/travelbag/domain/location/entity/Airline.java
@@ -1,0 +1,31 @@
+package com.example.travelbag.domain.location.entity;
+
+import com.example.travelbag.domain.common.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Airline extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String name;
+
+    private String url;
+
+    @OneToMany(mappedBy = "airline")
+    private List<LocationAirline> location_airlines = new ArrayList<>();
+
+}

--- a/src/main/java/com/example/travelbag/domain/location/entity/Location.java
+++ b/src/main/java/com/example/travelbag/domain/location/entity/Location.java
@@ -1,0 +1,35 @@
+package com.example.travelbag.domain.location.entity;
+
+import com.example.travelbag.domain.common.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Location extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "location")
+    private List<LocationAirline> location_airlines = new ArrayList<>();
+
+    public List<Airline> getAirlines() {
+        return location_airlines.stream()
+                .map(LocationAirline::getAirline)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/travelbag/domain/location/entity/LocationAirline.java
+++ b/src/main/java/com/example/travelbag/domain/location/entity/LocationAirline.java
@@ -1,0 +1,29 @@
+package com.example.travelbag.domain.location.entity;
+
+import com.example.travelbag.domain.common.model.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationAirline extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id")
+    private Location location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "airline_id")
+    private Airline airline;
+
+}

--- a/src/main/java/com/example/travelbag/domain/location/repository/LocationRepository.java
+++ b/src/main/java/com/example/travelbag/domain/location/repository/LocationRepository.java
@@ -1,0 +1,11 @@
+package com.example.travelbag.domain.location.repository;
+
+import com.example.travelbag.domain.location.entity.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LocationRepository extends JpaRepository<Location, Long> {
+    // 여행지 목록 조회 (이름 기준 정렬)
+    List<Location> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/example/travelbag/domain/location/service/LocationService.java
+++ b/src/main/java/com/example/travelbag/domain/location/service/LocationService.java
@@ -1,0 +1,35 @@
+package com.example.travelbag.domain.location.service;
+
+import com.example.travelbag.domain.location.dto.AirlineResponseDTO;
+import com.example.travelbag.domain.location.dto.LocationResponseDTO;
+import com.example.travelbag.domain.location.entity.Location;
+import com.example.travelbag.domain.location.repository.LocationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LocationService {
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    public List<LocationResponseDTO> getLocations() {
+        return locationRepository.findAllByOrderByNameAsc()
+                .stream()
+                .map(LocationResponseDTO::of)
+                .collect(Collectors.toList());
+    }
+
+    public List<AirlineResponseDTO> getAirlinesByLocation(Long location_id) {
+        Location location = locationRepository.findById(location_id)
+                .orElseThrow(() -> new RuntimeException("Location not found"));
+
+        return location.getAirlines()
+                .stream()
+                .map(AirlineResponseDTO::of)
+                .collect(Collectors.toList());  // AirlineResponseDTO를 통해 Airline 목록 반환
+    }
+}


### PR DESCRIPTION
## 📌 Issue Number
- open https://github.com/M7-TAVE/Backend/issues/

## 🪐 작업 내용
- 여행지 및 항공사 CRUD 구현
    - 여행지 조회 기능 `/location`
    - 여행지에 따른 항공사 조회 기능 `/location/airline?location_id=1`
    - 테스트 결과
       ![image](https://github.com/user-attachments/assets/589ec16e-84e2-4003-963f-df29188aed1f)       
       ![image](https://github.com/user-attachments/assets/741b7d98-4b89-43e0-828a-9dea0b1b5edd)


## ✅ PR 상세 내용
- 여행지 및 항공사 엔티티 CRUD 구현

## 📚 Reference
- x