### PR TITLE
feat: 여행지 및 항공사 엔티티 수정(BaseTimeEntity 제외) #2

### DIFF
--- a/src/main/java/com/example/travelbag/domain/location/dto/AirlineResponseDTO.java
+++ b/src/main/java/com/example/travelbag/domain/location/dto/AirlineResponseDTO.java
@@ -14,8 +14,6 @@ public class AirlineResponseDTO {
     private Long id;
     private String name;
     private String url;
-    private LocalDateTime createdDate;
-    private LocalDateTime lastModifiedDate;
 
     // Airline 객체를 받아서 DTO 객체로 변환
     public static AirlineResponseDTO of(Airline airline) {
@@ -23,8 +21,6 @@ public class AirlineResponseDTO {
                 .id(airline.getId())
                 .name(airline.getName())
                 .url(airline.getUrl())
-                .createdDate(airline.getCreatedDate())
-                .lastModifiedDate(airline.getLastModifiedDate())
                 .build();
     }
 }

--- a/src/main/java/com/example/travelbag/domain/location/dto/LocationResponseDTO.java
+++ b/src/main/java/com/example/travelbag/domain/location/dto/LocationResponseDTO.java
@@ -13,16 +13,12 @@ import java.time.LocalDateTime;
 public class LocationResponseDTO {
     private Long id;
     private String name;
-    private LocalDateTime createdDate;
-    private LocalDateTime lastModifiedDate;
 
     // Location 객체를 받아서 DTO 객체로 변환
     public static LocationResponseDTO of(Location location) {
         return LocationResponseDTO.builder()
                 .id(location.getId())
                 .name(location.getName())
-                .createdDate(location.getCreatedDate())
-                .lastModifiedDate(location.getLastModifiedDate())
                 .build();
     }
 }

--- a/src/main/java/com/example/travelbag/domain/location/entity/Airline.java
+++ b/src/main/java/com/example/travelbag/domain/location/entity/Airline.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Airline extends BaseTimeEntity {
+public class Airline {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/example/travelbag/domain/location/entity/Location.java
+++ b/src/main/java/com/example/travelbag/domain/location/entity/Location.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Location extends BaseTimeEntity {
+public class Location {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/example/travelbag/domain/location/entity/LocationAirline.java
+++ b/src/main/java/com/example/travelbag/domain/location/entity/LocationAirline.java
@@ -12,7 +12,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class LocationAirline extends BaseTimeEntity {
+public class LocationAirline {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)


### PR DESCRIPTION
## 📌 Issue Number
- open https://github.com/M7-TAVE/Backend/issues/

## 🪐 작업 내용
- 여행지 및 항공사 엔티티에 BaseTimeEntity 상속 제외
- 논의 결과, 여행지 및 항공사의 경우 개발 당시 데이터만 넣어주고 이후에 서비스 중 사용자의 데이터 입력이 없기 때문에 time 관련 필드를 넣지 않기로 함

## ✅ PR 상세 내용
- 여행지 및 항공사 엔티티에 BaseTimeEntity 상속 제외

## 📚 Reference
- x