### PR TITLE
feat: swagger 설명 추가, api 최대 호출 횟수 추가

### DIFF
--- a/src/main/java/com/example/travelbag/domain/location/controller/api/LocationApi.java
+++ b/src/main/java/com/example/travelbag/domain/location/controller/api/LocationApi.java
@@ -3,6 +3,10 @@ package com.example.travelbag.domain.location.controller.api;
 import com.example.travelbag.domain.location.dto.AirlineResponseDTO;
 import com.example.travelbag.domain.location.dto.CurrencyInfoDTO;
 import com.example.travelbag.domain.location.dto.LocationResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,15 +14,40 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
+@Tag(name = "Location", description = "여행지 관련 API")
 @RequestMapping("/location")
 public interface LocationApi {
 
+    @Operation(
+            summary = "여행지 목록 조회",    // 짧은 설명
+            description = "추천 여행지 목록을 조회합니다.",    // 상세 설명
+            security = @SecurityRequirement(name = "bearerAuth")   // API 호출 시 인증 요구사항(추후 수정 예정)
+    )
+    // 반환 상태 코드 및 의미
+    @ApiResponse(responseCode = "200", description = "여행지 목록 조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패")
     @GetMapping()
     ResponseEntity<List<LocationResponseDTO>> getLocations();
 
+    @Operation(
+            summary = "여행지별 주요 항공사 조회",    // 짧은 설명
+            description = "여행지별 주요 항공사 목록을 조회합니다.",    // 상세 설명
+            security = @SecurityRequirement(name = "bearerAuth")   // API 호출 시 인증 요구사항(추후 수정 예정)
+    )
+    // 반환 상태 코드 및 의미
+    @ApiResponse(responseCode = "200", description = "항공사 목록 조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패")
     @GetMapping("/airline")
     ResponseEntity<List<AirlineResponseDTO>> getAirlinesByLocation(@RequestParam(value="location_id") Long location_id);
 
+    @Operation(
+            summary = "여행지별 환율 조회",    // 짧은 설명
+            description = "여행지별 환율과 국가명, 통화코드를 조회합니다.",    // 상세 설명
+            security = @SecurityRequirement(name = "bearerAuth")   // API 호출 시 인증 요구사항
+    )
+    // 반환 상태 코드 및 의미
+    @ApiResponse(responseCode = "200", description = "환율 조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패")
     @GetMapping("/exchange-rate")
     ResponseEntity<CurrencyInfoDTO> getExchangeRate(@RequestParam(value="location_id") Long location_id);
 

--- a/src/main/java/com/example/travelbag/domain/location/service/LocationService.java
+++ b/src/main/java/com/example/travelbag/domain/location/service/LocationService.java
@@ -47,9 +47,16 @@ public class LocationService {
         double exchange_rate = 0.0;
         String searchDate = new SimpleDateFormat("yyyyMMdd").format(new Date());
 
+        int request_count = 0;    // 30회 이상 예외 발생으로 호출 시, 강제 종료 후 default 값 반환
+
         do {
             try {
+                if (request_count > 30) {
+                    exchange_rate = 1000.00;
+                    break;
+                }
                 exchange_rate = ExchangeRateUtils.fetchExchangeRate(searchDate, currency_unit);
+                request_count++;
             } catch (Exception e) {
                 // 예외 발생 시 하루 전 날짜로 변경
                 System.out.println(e.getMessage());


### PR DESCRIPTION
## 📌 Issue Number
- open https://github.com/M7-TAVE/Backend/issues/3

## 🪐 작업 내용
- location api를 swagger ui로 볼 때 api 설명 추가
- 환율 조회 시, 에러가 발생한 경우 이전 날로 다시 요청하도록 로직 구현 -> 무한루프에 빠지지 않게 하기 위해 30회 이상 api 호출 시, 강제 종료 후 기본값을 반환하도록 수정


## ✅ PR 상세 내용
- location api에 swagger 설명 추가
- 30회 이상 api 호출 시, 강제 종료 후 기본값을 반환하도록 수정

## 📚 Reference
- X