### PR TITLE
feat: controller, api 클래스 어노테이션 위치 변경 및 엔드포인트 파라미터 입력 방식 변경

### DIFF
--- a/src/main/java/com/example/travelbag/domain/attraction/controller/AttractionController.java
+++ b/src/main/java/com/example/travelbag/domain/attraction/controller/AttractionController.java
@@ -5,19 +5,20 @@ import com.example.travelbag.domain.attraction.dto.AttractionResponseDTO;
 import com.example.travelbag.domain.attraction.service.AttractionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
+@RequestMapping("/attraction")
 public class AttractionController implements AttractionApi {
 
     @Autowired
     private AttractionService attractionService;
 
     @Override
-    public ResponseEntity<List<AttractionResponseDTO>> getAttractionsByLocation(@RequestParam(value = "location_id") Long location_id) {
+    @GetMapping("/{location_id}")
+    public ResponseEntity<List<AttractionResponseDTO>> getAttractionsByLocation(@PathVariable Long location_id) {
         List<AttractionResponseDTO> airlines = attractionService.getAttractionsByLocation(location_id);
         return ResponseEntity.ok(airlines);
     }

--- a/src/main/java/com/example/travelbag/domain/attraction/controller/api/AttractionApi.java
+++ b/src/main/java/com/example/travelbag/domain/attraction/controller/api/AttractionApi.java
@@ -2,18 +2,15 @@ package com.example.travelbag.domain.attraction.controller.api;
 
 import com.example.travelbag.domain.attraction.dto.AttractionResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@Tag(name = "Attraction", description = "관광지 관련 API")
-@RequestMapping("/attraction")
+@Tag(name = "관광지", description = "관광지 관련 API")
 public interface AttractionApi {
 
     @Operation(
@@ -24,6 +21,6 @@ public interface AttractionApi {
     // 반환 상태 코드 및 의미
     @ApiResponse(responseCode = "200", description = "관광지 목록 조회 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패")
-    @GetMapping()
-    ResponseEntity<List<AttractionResponseDTO>> getAttractionsByLocation(@RequestParam(value="location_id") Long location_id);
+    ResponseEntity<List<AttractionResponseDTO>> getAttractionsByLocation(
+            @Parameter(description = "여행지 ID", required = true) Long location_id);
 }

--- a/src/main/java/com/example/travelbag/domain/location/controller/LocationController.java
+++ b/src/main/java/com/example/travelbag/domain/location/controller/LocationController.java
@@ -7,31 +7,34 @@ import com.example.travelbag.domain.location.dto.LocationResponseDTO;
 import com.example.travelbag.domain.location.service.LocationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
+@RequestMapping("/location")
 public class LocationController implements LocationApi {
 
     @Autowired
     private LocationService locationService;
 
     @Override
+    @GetMapping()
     public ResponseEntity<List<LocationResponseDTO>> getLocations() {
         List<LocationResponseDTO> locations = locationService.getLocations();
         return ResponseEntity.ok(locations);
     }
 
     @Override
-    public ResponseEntity<List<AirlineResponseDTO>> getAirlinesByLocation(@RequestParam(value="location_id") Long location_id) {
+    @GetMapping("/airline/{location_id}")
+    public ResponseEntity<List<AirlineResponseDTO>> getAirlinesByLocation(@PathVariable Long location_id) {
         List<AirlineResponseDTO> airlines = locationService.getAirlinesByLocation(location_id);
         return ResponseEntity.ok(airlines);
     }
 
     @Override
-    public ResponseEntity<CurrencyInfoDTO> getExchangeRate(@RequestParam(value="location_id") Long location_id){
+    @GetMapping("/exchange-rate/{location_id}")
+    public ResponseEntity<CurrencyInfoDTO> getExchangeRate(@PathVariable Long location_id){
         CurrencyInfoDTO currency_info = locationService.getExchangeRate(location_id);
         return ResponseEntity.ok(currency_info);
     }

--- a/src/main/java/com/example/travelbag/domain/location/controller/api/LocationApi.java
+++ b/src/main/java/com/example/travelbag/domain/location/controller/api/LocationApi.java
@@ -4,18 +4,15 @@ import com.example.travelbag.domain.location.dto.AirlineResponseDTO;
 import com.example.travelbag.domain.location.dto.CurrencyInfoDTO;
 import com.example.travelbag.domain.location.dto.LocationResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@Tag(name = "Location", description = "여행지 관련 API")
-@RequestMapping("/location")
+@Tag(name = "여행지", description = "여행지 CRUD API")
 public interface LocationApi {
 
     @Operation(
@@ -26,7 +23,6 @@ public interface LocationApi {
     // 반환 상태 코드 및 의미
     @ApiResponse(responseCode = "200", description = "여행지 목록 조회 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패")
-    @GetMapping()
     ResponseEntity<List<LocationResponseDTO>> getLocations();
 
     @Operation(
@@ -37,8 +33,8 @@ public interface LocationApi {
     // 반환 상태 코드 및 의미
     @ApiResponse(responseCode = "200", description = "항공사 목록 조회 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패")
-    @GetMapping("/airline")
-    ResponseEntity<List<AirlineResponseDTO>> getAirlinesByLocation(@RequestParam(value="location_id") Long location_id);
+    ResponseEntity<List<AirlineResponseDTO>> getAirlinesByLocation(
+            @Parameter(description = "여행지 ID", required = true) Long location_id);
 
     @Operation(
             summary = "여행지별 환율 조회",    // 짧은 설명
@@ -48,7 +44,7 @@ public interface LocationApi {
     // 반환 상태 코드 및 의미
     @ApiResponse(responseCode = "200", description = "환율 조회 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패")
-    @GetMapping("/exchange-rate")
-    ResponseEntity<CurrencyInfoDTO> getExchangeRate(@RequestParam(value="location_id") Long location_id);
+    ResponseEntity<CurrencyInfoDTO> getExchangeRate(
+            @Parameter(description = "여행지 ID", required = true) Long location_id);
 
 }

--- a/src/main/java/com/example/travelbag/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/example/travelbag/domain/restaurant/controller/RestaurantController.java
@@ -5,19 +5,20 @@ import com.example.travelbag.domain.restaurant.dto.RestaurantResponseDTO;
 import com.example.travelbag.domain.restaurant.service.RestaurantService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
+@RequestMapping("/restaurant")
 public class RestaurantController implements RestaurantApi {
 
     @Autowired
     private RestaurantService restaurantService;
 
     @Override
-    public ResponseEntity<List<RestaurantResponseDTO>> getRestaurantsByLocation(@RequestParam(value = "location_id") Long location_id) {
+    @GetMapping("/{location_id}")
+    public ResponseEntity<List<RestaurantResponseDTO>> getRestaurantsByLocation(@PathVariable Long location_id) {
         List<RestaurantResponseDTO> airlines = restaurantService.getRestaurantsByLocation(location_id);
         return ResponseEntity.ok(airlines);
     }

--- a/src/main/java/com/example/travelbag/domain/restaurant/controller/api/RestaurantApi.java
+++ b/src/main/java/com/example/travelbag/domain/restaurant/controller/api/RestaurantApi.java
@@ -2,18 +2,15 @@ package com.example.travelbag.domain.restaurant.controller.api;
 
 import com.example.travelbag.domain.restaurant.dto.RestaurantResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@Tag(name = "Restaurant", description = "맛집 관련 API")
-@RequestMapping("/restaurant")
+@Tag(name = "맛집", description = "맛집 관련 API")
 public interface RestaurantApi {
 
     @Operation(
@@ -24,6 +21,6 @@ public interface RestaurantApi {
     // 반환 상태 코드 및 의미
     @ApiResponse(responseCode = "200", description = "맛집 목록 조회 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패")
-    @GetMapping()
-    ResponseEntity<List<RestaurantResponseDTO>> getRestaurantsByLocation(@RequestParam(value="location_id") Long location_id);
+    ResponseEntity<List<RestaurantResponseDTO>> getRestaurantsByLocation(
+            @Parameter(description = "여행지 ID", required = true) Long location_id);
 }

--- a/src/main/java/com/example/travelbag/domain/souvenir/controller/SouvenirController.java
+++ b/src/main/java/com/example/travelbag/domain/souvenir/controller/SouvenirController.java
@@ -5,19 +5,20 @@ import com.example.travelbag.domain.souvenir.dto.SouvenirResponseDTO;
 import com.example.travelbag.domain.souvenir.service.SouvenirService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
+@RequestMapping("/souvenir")
 public class SouvenirController implements SouvenirApi {
 
     @Autowired
     private SouvenirService souvenirService;
 
     @Override
-    public ResponseEntity<List<SouvenirResponseDTO>> getSouvenirsByLocation(@RequestParam(value = "location_id") Long location_id) {
+    @GetMapping("/{location_id}")
+    public ResponseEntity<List<SouvenirResponseDTO>> getSouvenirsByLocation(@PathVariable Long location_id) {
         List<SouvenirResponseDTO> airlines = souvenirService.getSouvenirsByLocation(location_id);
         return ResponseEntity.ok(airlines);
     }

--- a/src/main/java/com/example/travelbag/domain/souvenir/controller/api/SouvenirApi.java
+++ b/src/main/java/com/example/travelbag/domain/souvenir/controller/api/SouvenirApi.java
@@ -2,18 +2,15 @@ package com.example.travelbag.domain.souvenir.controller.api;
 
 import com.example.travelbag.domain.souvenir.dto.SouvenirResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@Tag(name = "Souvenir", description = "기념품 관련 API")
-@RequestMapping("/souvenir")
+@Tag(name = "기념품", description = "기념품 관련 API")
 public interface SouvenirApi {
 
     @Operation(
@@ -24,6 +21,6 @@ public interface SouvenirApi {
     // 반환 상태 코드 및 의미
     @ApiResponse(responseCode = "200", description = "기념품 목록 조회 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패")
-    @GetMapping()
-    ResponseEntity<List<SouvenirResponseDTO>> getSouvenirsByLocation(@RequestParam(value="location_id") Long location_id);
+    ResponseEntity<List<SouvenirResponseDTO>> getSouvenirsByLocation(
+            @Parameter(description = "여행지 ID", required = true) Long location_id);
 }


### PR DESCRIPTION
## 📌 Issue Number
- close https://github.com/M7-TAVE/Backend/issues/3
- open https://github.com/M7-TAVE/Backend/issues/14

## 🪐 작업 내용
- api 개발 중인 다른 팀원의 코드를 기반으로 코드 구조 수정
- api 클래스에 함께 두었던 `@RequestMapping()`, `@GetMapping()` 같은 매핑 어노테이션을 Controller 클래스로 이동
    - api 클래스에는 swagger 문서 작성을 위한 어노테이션만 남기는 것이 유지보수와 가독성에 좋을 것이라고 판단했기 때문에, 팀원의 방식을 따라감
- 기존에 `@RequestParam` 로 파라미터를 받아왔으나, `@PathVariable` 를 사용해 파라미터를 받아오도록 수정
    - 기존 방식보다 직관적이고, 여행 팁 페이지에서 받아오는 파라미터는 조회에 있어 필수적이기 때문에 api 성격상 `@PathVariable` 가 더욱 적절하다고 판단했기 때문


## ✅ PR 상세 내용
- 어노테이션 위치 변경 및 파라미터 입력 방식 변경

## 📚 Reference
- X