### PR TITLE
feat: ID GenerationType 변경

### DIFF
--- a/src/main/java/com/example/travelbag/domain/attraction/entity/Attraction.java
+++ b/src/main/java/com/example/travelbag/domain/attraction/entity/Attraction.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 public class Attraction {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/example/travelbag/domain/location/entity/Airline.java
+++ b/src/main/java/com/example/travelbag/domain/location/entity/Airline.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class Airline {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/example/travelbag/domain/location/entity/Location.java
+++ b/src/main/java/com/example/travelbag/domain/location/entity/Location.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 public class Location {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/example/travelbag/domain/location/entity/LocationAirline.java
+++ b/src/main/java/com/example/travelbag/domain/location/entity/LocationAirline.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 public class LocationAirline {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/travelbag/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/example/travelbag/domain/restaurant/entity/Restaurant.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 public class Restaurant {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/example/travelbag/domain/souvenir/entity/Souvenir.java
+++ b/src/main/java/com/example/travelbag/domain/souvenir/entity/Souvenir.java
@@ -16,7 +16,7 @@ import lombok.Setter;
 public class Souvenir {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;


### PR DESCRIPTION
## 📌 Issue Number
- close https://github.com/M7-TAVE/Backend/issues/14

## 🪐 작업 내용
- entity 개발 시, `@GeneratedValue(strategy = GenerationType.AUTO)` 로 설정하였으나, RDS 연결 테스트 중 sequence 테이블이 자동 생성됨. 의도한 방식이 아니기 때문에 `GenerationType`을 `IDENTITY` 로 변경


## ✅ PR 상세 내용
- ID GenerationType 변경

## 📚 Reference
- X