### PR TITLE
chore: 설정 파일 수정사항 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,13 +30,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.json:json:20210307'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
+//    runtimeOnly 'com.h2database:h2'
+    implementation 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,27 @@
 spring.application.name=travelbag
 
-# H2
-spring.datasource.url=jdbc:h2:tcp://localhost/~/travelbag
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
+# RDS
+spring.datasource.url= ${DB_URL}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Import .env file
+spring.config.import=optional:file:.env[.properties]
 
 # JPA
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.hibernate.ddl-auto=create
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.properties.hibernate.default_schema=travelbag_db
+spring.jpa.hibernate.ddl-auto=update
+
+
+# JPA query log
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate.type.descriptor.sql=trace
+spring.jpa.properties.hibernate.use_sql_comments=true
+
 
 # exchange rate API authKey
 exchange.rate.api.authKey=prRjAsfBpGK69r6IPgeBfu115Vvwok9b

--- a/src/test/java/com/example/travelbag/TravelbagApplicationTests.java
+++ b/src/test/java/com/example/travelbag/TravelbagApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class TravelbagApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
-
 }


### PR DESCRIPTION
## 📌 Issue Number
- open https://github.com/M7-TAVE/Backend/issues/29

## 🪐 작업 내용
- 원활한 cicd 작업을 위해 디스코드에 별도로 업로드했던 설정 관련 수정사항을 main에 반영하기 위해 push합니다.
    - gradle에 mysql, .env 파일 적용을 위한 의존성 추가
    - `application.properties`
        - RDS 연결 관련 설정
        - JPA log 출력 설정
        - .env 파일 import
- 테스트 클래스에 빈 테스트용 메소드가 빌드 시에 테스트를 실패했다는 에러가 발생해 삭제했습니다.

## ✅ PR 상세 내용
- gradle에 의존성 추가
- properties에 rds 연결 설정, jpa log 설정, .env 설정 추가
- 불필요한 테스트 코드 삭제

## 📚 Reference
- x